### PR TITLE
Feat: allow user to kick off an MCP server for AI agents to connect to

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1003,6 +1003,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-server"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "495c05f60d6df0093e8fb6e74aa5846a0ad06abaf96d76166283720bf740f8ab"
+dependencies = [
+ "bytes",
+ "fs-err",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-util",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1393,6 +1409,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "cookie"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eac901828f88a5241ee0600950ab981148a18f2f756900ffba1b125ca6a3ef9"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna",
+ "log",
+ "publicsuffix",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1740,6 +1785,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "document-features"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95249b50c6c185bee49034bcb378a49dc2b5dff0be90ff6616d31d64febab05d"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
 name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2045,6 +2099,7 @@ dependencies = [
  "ant-releases",
  "apexcharts-rs",
  "async-stream",
+ "async-trait",
  "axum",
  "bs58",
  "bytes",
@@ -2072,6 +2127,7 @@ dependencies = [
  "prettytable",
  "rand 0.9.2",
  "reqwest",
+ "rust-mcp-sdk",
  "semver 1.0.27",
  "serde",
  "serde_json",
@@ -2085,6 +2141,16 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "fs-err"
+version = "3.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44f150ffc8782f35521cec2b23727707cb4045706ba3c854e86bef66b3a8cdbd"
+dependencies = [
+ "autocfg",
+ "tokio",
 ]
 
 [[package]]
@@ -3359,6 +3425,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
+name = "litrs"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5e54036fe321fd421e10d732f155734c4e4afd610dd556d9a82833ab3ee0bed"
+
+[[package]]
 name = "local-ip-address"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4103,6 +4175,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "psl-types"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
+
+[[package]]
+name = "publicsuffix"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42ea446cab60335f76979ec15e12619a2165b5ae2c12166bef27d283a9fadf"
+dependencies = [
+ "idna",
+ "psl-types",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4465,7 +4553,10 @@ checksum = "d429f34c8092b2d42c7c93cec323bb4adeb7c67698f70839adec842ec10c7ceb"
 dependencies = [
  "base64",
  "bytes",
+ "cookie",
+ "cookie_store",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -4474,6 +4565,7 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
+ "mime_guess",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -4485,12 +4577,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots 1.0.2",
 ]
@@ -4596,6 +4690,72 @@ name = "ruint-macro"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
+
+[[package]]
+name = "rust-mcp-macros"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b647a85c9da2eaf14e67d39cb067a8157a66bd2c0dc53ef1051a84f45edfae24"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "rust-mcp-schema"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bb65fd293dbbfabaacba1512b3948cdd9bf31ad1f2c0fed4962052b590c5c44"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "rust-mcp-sdk"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "961ec01d0bedecf488388e6b1cf04170f9badab4927061c6592ffa385c02c6c9"
+dependencies = [
+ "async-trait",
+ "axum",
+ "axum-server",
+ "base64",
+ "futures",
+ "hyper",
+ "rust-mcp-macros",
+ "rust-mcp-schema",
+ "rust-mcp-transport",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.16",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "rust-mcp-transport"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35feabc5e4667019dc262178724c94cbced6f43959af15e214b52f79243f55ed"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures",
+ "reqwest",
+ "rust-mcp-schema",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.16",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+]
 
 [[package]]
 name = "rustc-demangle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,8 @@ nom-openmetrics = { version = "0.2.0", optional = true }
 prettytable = "0.10.0"
 rand = "0.9"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"], optional = true }
+rust-mcp-sdk = { version = "0.7.0", optional = true, default-features = false, features = ["server","macros","streamable-http","hyper-server","2025_06_18"] }
+async-trait = { version = "0.1.89", optional = true }
 semver = { version = "1.0", optional = true }
 serde = "1.0"
 serde_json = "1.0"
@@ -63,6 +65,7 @@ ssr = [
     "dep:ant-releases",
     "dep:alloy",
     "dep:async-stream",
+    "dep:async-trait",
     "dep:axum",
     "dep:bs58",
     "dep:http-body-util",
@@ -75,6 +78,7 @@ ssr = [
     "dep:local-ip-address",
     "dep:nom-openmetrics",
     "dep:reqwest",
+    "dep:rust-mcp-sdk",
     "dep:semver",
     "dep:sqlx",
     "dep:sysinfo",

--- a/README.md
+++ b/README.md
@@ -91,6 +91,17 @@ When setting up nodes, you can define their connection type and custom data dire
 <img src="img/screenshot_02.png" width="300" height="373" />
 <img src="img/screenshot_02_b.png" width="300" height="248" />
 
+### MCP Server for Integration with AI Agents
+
+The MCP server of Formicaio is designed to seamlessly integrate with any AI agent. This flexibility allows users to leverage the capabilities of various AI models with Formicaio. To illustrate this integration, check out the video demonstration below that showcases how the MCP server can be effectively combined with [n8n](https://n8n.io), an open-source workflow automation tool. 
+
+The video highlights the simplicity of connecting Formicaio with AI agents to automate tasks and streamline processes. You can see the integration in action using [n8n](https://n8n.io). We interact with Formicaio through an AI agent via chat, as well as demonstrate how to schedule a task that monitors CPU usage. Based on the detected CPU capacity on the host, the system can automatically request Formicaio to add or remove nodes, ensuring optimal performance. This is the AI prompt used in this showcase:
+```text
+Make sure the CPU usage on the host is below 50%. If it is, add a new node instance on Formicaio with the same properties as the existing nodes, using a port number that is one higher than the highest current port. Also, keep the total number of nodes to 3; if there are more than 3, remove the extra ones.
+```
+
+<img src="img/formicaio_mcp_with_n8n.gif" alt="Animation showing Formicaio MCP integration with n8n workflow automation" />
+
 ## Installation & Deployment
 
 Formicaio can be deployed and executed in several ways to suit your needs:
@@ -113,6 +124,17 @@ Formicaio can be deployed and executed in several ways to suit your needs:
    ```
 
 Upon startup, Formicaio will automatically download the latest node binary. Once complete, the GUI frontend will be accessible at `http://localhost:52100`.
+
+You can easily enable the MCP Server by using the `--mcp` flag. This command will launch the MCP Server on the default address of `127.0.0.1:52105`:
+   ```bash
+   # Linux/macOS
+   ./formicaio start --mcp
+   
+   # Windows
+   formicaio.exe start --mcp
+   ```
+
+If you wish to specify a different IP address and port for the MCP server, you can do so by using the `--mcp-addr <IP>:<port>` argument.
 
 #### Command Line Interface
 

--- a/src/bg_tasks/mcp.rs
+++ b/src/bg_tasks/mcp.rs
@@ -77,7 +77,7 @@ pub fn start_mcp_server(addr: SocketAddr, app_ctx: AppContext, node_manager: Nod
             ..Default::default() // Using default values for other fields
         },
         meta: None,
-        instructions: Some("server instructions...".to_string()),
+        instructions: Some("Formicaio MCP Server - Use 'ListTools' to discover available node management tools. Connect via HTTP SSE or standard MCP protocols.".to_string()),
         protocol_version: LATEST_PROTOCOL_VERSION.to_string(),
     };
 
@@ -94,6 +94,7 @@ pub fn start_mcp_server(addr: SocketAddr, app_ctx: AppContext, node_manager: Nod
         HyperServerOptions {
             host: addr.ip().to_string(),
             port: addr.port(),
+            sse_support: false,
             ping_interval: Duration::from_secs(5),
             event_store: Some(Arc::new(InMemoryEventStore::default())), // enable resumability
             ..Default::default()

--- a/src/bg_tasks/mcp.rs
+++ b/src/bg_tasks/mcp.rs
@@ -1,0 +1,116 @@
+use super::mcp_tools::*;
+use crate::{app_context::AppContext, node_mgr::NodeManager};
+
+use async_trait::async_trait;
+use leptos::logging;
+use rust_mcp_sdk::{
+    McpServer,
+    event_store::InMemoryEventStore,
+    mcp_server::{HyperServerOptions, ServerHandler, hyper_server},
+    schema::{
+        CallToolRequest, CallToolResult, Implementation, InitializeResult, LATEST_PROTOCOL_VERSION,
+        ListToolsRequest, ListToolsResult, RpcError, ServerCapabilities, ServerCapabilitiesTools,
+        schema_utils::CallToolError,
+    },
+};
+use std::{net::SocketAddr, sync::Arc, time::Duration};
+
+pub struct McpServerHandler {
+    app_ctx: AppContext,
+    node_manager: NodeManager,
+}
+
+#[async_trait]
+impl ServerHandler for McpServerHandler {
+    // Handle ListToolsRequest, return list of available tools as ListToolsResult
+    async fn handle_list_tools_request(
+        &self,
+        _request: ListToolsRequest,
+        _runtime: Arc<dyn McpServer>,
+    ) -> std::result::Result<ListToolsResult, RpcError> {
+        Ok(ListToolsResult {
+            meta: None,
+            next_cursor: None,
+            tools: FormicaioTools::tools(),
+        })
+    }
+
+    /// Handles incoming CallToolRequest and processes it using the appropriate tool.
+    async fn handle_call_tool_request(
+        &self,
+        request: CallToolRequest,
+        _runtime: Arc<dyn McpServer>,
+    ) -> std::result::Result<CallToolResult, CallToolError> {
+        // Attempt to convert request parameters into FormicaioTools enum
+        let tool_params: FormicaioTools =
+            FormicaioTools::try_from(request.params).map_err(CallToolError::new)?;
+
+        // Match the tool variant and execute its corresponding logic
+        match tool_params {
+            FormicaioTools::FetchStats(tool) => tool.call_tool(&self.app_ctx).await,
+            FormicaioTools::NodeInstances(tool) => {
+                tool.call_tool(&self.app_ctx, &self.node_manager).await
+            }
+            FormicaioTools::CreateNodeInstance(tool) => tool.call_tool(&self.node_manager).await,
+            FormicaioTools::StartNodeInstance(tool) => tool.call_tool(&self.node_manager).await,
+            FormicaioTools::StopNodeInstance(tool) => tool.call_tool(&self.node_manager).await,
+            FormicaioTools::DeleteNodeInstance(tool) => tool.call_tool(&self.node_manager).await,
+            FormicaioTools::UpgradeNodeInstance(tool) => tool.call_tool(&self.node_manager).await,
+            FormicaioTools::RecycleNodeInstance(tool) => tool.call_tool(&self.node_manager).await,
+        }
+    }
+}
+
+// Kick off the MCP server to listen on the given address and port.
+pub fn start_mcp_server(addr: SocketAddr, app_ctx: AppContext, node_manager: NodeManager) {
+    // Define server details and capabilities
+    let server_details = InitializeResult {
+        // server name and version
+        server_info: Implementation {
+            name: "Formicaio MCP Server SSE".to_string(),
+            version: "0.1.0".to_string(),
+            title: Some("Formicaio MCP Server SSE".to_string()),
+        },
+        capabilities: ServerCapabilities {
+            // indicates that server support mcp tools
+            tools: Some(ServerCapabilitiesTools { list_changed: None }),
+            ..Default::default() // Using default values for other fields
+        },
+        meta: None,
+        instructions: Some("server instructions...".to_string()),
+        protocol_version: LATEST_PROTOCOL_VERSION.to_string(),
+    };
+
+    // instantiate our custom handler for handling MCP messages
+    let handler = McpServerHandler {
+        app_ctx,
+        node_manager,
+    };
+
+    // instantiate HyperServer, providing `server_details`, `handler` and HyperServerOptions
+    let server = hyper_server::create_server(
+        server_details,
+        handler,
+        HyperServerOptions {
+            host: addr.ip().to_string(),
+            port: addr.port(),
+            ping_interval: Duration::from_secs(5),
+            event_store: Some(Arc::new(InMemoryEventStore::default())), // enable resumability
+            ..Default::default()
+        },
+    );
+
+    // Start the server
+    tokio::spawn(async {
+        logging::log!(
+            "{}",
+            server
+                .server_info(None)
+                .await
+                .unwrap_or_else(|err| err.to_string())
+        );
+        if let Err(err) = server.start().await {
+            logging::error!("Failed to start MCP server: {err:?}");
+        }
+    });
+}

--- a/src/bg_tasks/mcp_tools.rs
+++ b/src/bg_tasks/mcp_tools.rs
@@ -1,0 +1,241 @@
+use crate::{
+    app_context::AppContext, node_mgr::NodeManager, server_api::parse_and_validate_addr,
+    types::NodeOpts,
+};
+
+use rust_mcp_sdk::{
+    macros::{JsonSchema, mcp_tool},
+    schema::{CallToolResult, TextContent, schema_utils::CallToolError},
+    tool_box,
+};
+use std::{net::IpAddr, path::PathBuf, str::FromStr};
+
+// Serialise object and return a result ready to return as the tool response
+fn serialise_to_tool_response<T: serde::Serialize>(
+    object: &T,
+) -> Result<CallToolResult, CallToolError> {
+    match serde_json::to_string(object) {
+        Ok(str) => Ok(CallToolResult::text_content(vec![TextContent::from(str)])),
+        Err(err) => Err(CallToolError::from_message(err.to_string())),
+    }
+}
+
+#[mcp_tool(
+    name = "fetch_stats",
+    description = "Return up to date aggregated nodes stats."
+)]
+#[derive(Debug, ::serde::Deserialize, ::serde::Serialize, JsonSchema)]
+pub struct FetchStats {}
+impl FetchStats {
+    pub async fn call_tool(&self, app_ctx: &AppContext) -> Result<CallToolResult, CallToolError> {
+        let stats = app_ctx.stats.read().await.clone();
+        serialise_to_tool_response(&stats)
+    }
+}
+
+#[mcp_tool(
+    name = "nodes_instances",
+    description = "Retrieve the list of node instances and their configured options."
+)]
+#[derive(Debug, ::serde::Deserialize, ::serde::Serialize, JsonSchema)]
+pub struct NodeInstances {}
+impl NodeInstances {
+    pub async fn call_tool(
+        &self,
+        app_ctx: &AppContext,
+        node_manager: &NodeManager,
+    ) -> Result<CallToolResult, CallToolError> {
+        match node_manager
+            .filtered_nodes_list(None, app_ctx.nodes_metrics.clone())
+            .await
+        {
+            Ok(nodes) => serialise_to_tool_response(&nodes),
+            Err(err) => Err(CallToolError::from_message(err.to_string())),
+        }
+    }
+}
+
+#[mcp_tool(
+    name = "create_node_instance",
+    description = "Create a new node instance."
+)]
+#[derive(Debug, ::serde::Deserialize, ::serde::Serialize, JsonSchema)]
+pub struct CreateNodeInstance {
+    /// Listening IP address set by the user for the node (IPv4 or IPv6, including special values like `0.0.0.0` or `::`)
+    pub node_ip: String,
+    /// TCP port used by the node for main operations
+    pub port: u16,
+    /// TCP port used by the node for metrics reporting
+    pub metrics_port: u16,
+    /// Hex-encoded rewards address for the node
+    pub rewards_addr: String,
+    /// Whether UPnP is enabled for this node
+    pub upnp: bool,
+    /// Whether reachability check is enabled for this node
+    pub reachability_check: bool,
+    /// Whether node logs are enabled for this node
+    pub node_logs: bool,
+    /// Whether to automatically start the node after creation
+    pub auto_start: bool,
+    /// Custom data directory path for this node instance
+    pub data_dir_path: String,
+}
+impl CreateNodeInstance {
+    pub async fn call_tool(
+        &self,
+        node_manager: &NodeManager,
+    ) -> Result<CallToolResult, CallToolError> {
+        // validate rewards address before proceeding
+        if let Err(err) = parse_and_validate_addr(&self.rewards_addr) {
+            return Err(CallToolError::from_message(err.to_string()));
+        }
+
+        let node_opts = NodeOpts {
+            node_ip: IpAddr::from_str(&self.node_ip)
+                .map_err(|err| CallToolError::from_message(err.to_string()))?,
+            port: self.port,
+            metrics_port: self.metrics_port,
+            rewards_addr: self.rewards_addr.clone(),
+            upnp: self.upnp,
+            reachability_check: self.reachability_check,
+            node_logs: self.node_logs,
+            auto_start: self.auto_start,
+            data_dir_path: PathBuf::from(&self.data_dir_path),
+        };
+
+        match node_manager.create_node_instance(node_opts).await {
+            Ok(info) => serialise_to_tool_response(&info),
+            Err(err) => Err(CallToolError::from_message(err.to_string())),
+        }
+    }
+}
+
+#[mcp_tool(
+    name = "start_node_instance",
+    description = "Start node instance with given Id."
+)]
+#[derive(Debug, ::serde::Deserialize, ::serde::Serialize, JsonSchema)]
+pub struct StartNodeInstance {
+    node_id: String,
+}
+impl StartNodeInstance {
+    pub async fn call_tool(
+        &self,
+        node_manager: &NodeManager,
+    ) -> Result<CallToolResult, CallToolError> {
+        match node_manager
+            .start_node_instance(self.node_id.clone().into())
+            .await
+        {
+            Ok(()) => Ok(CallToolResult::text_content(vec![])),
+            Err(err) => Err(CallToolError::from_message(err.to_string())),
+        }
+    }
+}
+
+#[mcp_tool(
+    name = "stop_node_instance",
+    description = "Stop node instance with given Id."
+)]
+#[derive(Debug, ::serde::Deserialize, ::serde::Serialize, JsonSchema)]
+pub struct StopNodeInstance {
+    node_id: String,
+}
+impl StopNodeInstance {
+    pub async fn call_tool(
+        &self,
+        node_manager: &NodeManager,
+    ) -> Result<CallToolResult, CallToolError> {
+        match node_manager
+            .stop_node_instance(self.node_id.clone().into())
+            .await
+        {
+            Ok(()) => Ok(CallToolResult::text_content(vec![])),
+            Err(err) => Err(CallToolError::from_message(err.to_string())),
+        }
+    }
+}
+
+#[mcp_tool(
+    name = "delete_node_instance",
+    description = "Delete node instance with given Id."
+)]
+#[derive(Debug, ::serde::Deserialize, ::serde::Serialize, JsonSchema)]
+pub struct DeleteNodeInstance {
+    node_id: String,
+}
+impl DeleteNodeInstance {
+    pub async fn call_tool(
+        &self,
+        node_manager: &NodeManager,
+    ) -> Result<CallToolResult, CallToolError> {
+        match node_manager
+            .delete_node_instance(self.node_id.clone().into())
+            .await
+        {
+            Ok(()) => Ok(CallToolResult::text_content(vec![])),
+            Err(err) => Err(CallToolError::from_message(err.to_string())),
+        }
+    }
+}
+
+#[mcp_tool(
+    name = "upgrade_node_instance",
+    description = "Upgrade node instance with given Id."
+)]
+#[derive(Debug, ::serde::Deserialize, ::serde::Serialize, JsonSchema)]
+pub struct UpgradeNodeInstance {
+    node_id: String,
+}
+impl UpgradeNodeInstance {
+    pub async fn call_tool(
+        &self,
+        node_manager: &NodeManager,
+    ) -> Result<CallToolResult, CallToolError> {
+        match node_manager
+            .upgrade_node_instance(&self.node_id.clone().into())
+            .await
+        {
+            Ok(()) => Ok(CallToolResult::text_content(vec![])),
+            Err(err) => Err(CallToolError::from_message(err.to_string())),
+        }
+    }
+}
+
+#[mcp_tool(
+    name = "recycle_node_instance",
+    description = "Recycle node instance with given Id."
+)]
+#[derive(Debug, ::serde::Deserialize, ::serde::Serialize, JsonSchema)]
+pub struct RecycleNodeInstance {
+    node_id: String,
+}
+impl RecycleNodeInstance {
+    pub async fn call_tool(
+        &self,
+        node_manager: &NodeManager,
+    ) -> Result<CallToolResult, CallToolError> {
+        match node_manager
+            .recycle_node_instance(self.node_id.clone().into())
+            .await
+        {
+            Ok(()) => Ok(CallToolResult::text_content(vec![])),
+            Err(err) => Err(CallToolError::from_message(err.to_string())),
+        }
+    }
+}
+
+// Generates an enum named FormicaioTools, list of available tools.
+tool_box!(
+    FormicaioTools,
+    [
+        FetchStats,
+        NodeInstances,
+        CreateNodeInstance,
+        StartNodeInstance,
+        StopNodeInstance,
+        DeleteNodeInstance,
+        UpgradeNodeInstance,
+        RecycleNodeInstance
+    ]
+);

--- a/src/bg_tasks/mod.rs
+++ b/src/bg_tasks/mod.rs
@@ -1,6 +1,8 @@
 mod batches;
 #[cfg(not(feature = "lcd-disabled"))]
 mod lcd;
+mod mcp;
+mod mcp_tools;
 mod metrics_client;
 mod tasks;
 mod tasks_ctx;
@@ -12,6 +14,7 @@ use super::{
 };
 
 pub use batches::{ActionsBatchError, prepare_node_action_batch};
+pub use mcp::start_mcp_server;
 pub use metrics_client::NodesMetrics;
 
 use alloy::sol;

--- a/src/cli_cmds.rs
+++ b/src/cli_cmds.rs
@@ -64,11 +64,11 @@ pub struct StartSubcommands {
     /// Setting this value will override the 'DB_PATH' and 'NODE_MGR_ROOT_DIR' environment variables.
     #[structopt(long)]
     pub data_dir_path: Option<PathBuf>,
-    /// Kick off an MCP server for AI agents to connect to with either through HTTP Streamable or SSE protocols.
+    /// Kick off an MCP server for AI agents to connect with either through HTTP Streamable or SSE protocols.
     #[structopt(long)]
     pub mcp: bool,
     /// MCP server address and port
-    #[structopt(long, default_value = "127.0.0.1:8080")]
+    #[structopt(long, default_value = "127.0.0.1:52105")]
     pub mcp_addr: SocketAddr,
 }
 

--- a/src/cli_cmds.rs
+++ b/src/cli_cmds.rs
@@ -64,6 +64,12 @@ pub struct StartSubcommands {
     /// Setting this value will override the 'DB_PATH' and 'NODE_MGR_ROOT_DIR' environment variables.
     #[structopt(long)]
     pub data_dir_path: Option<PathBuf>,
+    /// Kick off an MCP server for AI agents to connect to with either through HTTP Streamable or SSE protocols.
+    #[structopt(long)]
+    pub mcp: bool,
+    /// MCP server address and port
+    #[structopt(long, default_value = "127.0.0.1:8080")]
+    pub mcp_addr: SocketAddr,
 }
 
 #[derive(Debug, PartialEq, StructOpt)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,7 @@ async fn start_backend(
     use eyre::WrapErr;
     use formicaio::{
         app::{App, AppContext, ServerGlobalState, shell},
-        bg_tasks::{spawn_bg_tasks, start_mcp_server},
+        bg_tasks::spawn_bg_tasks,
         db_client::DbClient,
         node_mgr::NodeManager,
     };
@@ -111,8 +111,9 @@ async fn start_backend(
     );
 
     // If enabled by the user start the MCP server
+    #[cfg(feature = "native")]
     if sub_cmds.mcp {
-        start_mcp_server(
+        formicaio::bg_tasks::start_mcp_server(
             sub_cmds.mcp_addr,
             app_state.app_ctx.clone(),
             app_state.node_manager.clone(),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Optional MCP server for AI agent integration; enable with --mcp and configure address via --mcp-addr (default 127.0.0.1:52105).
  - Exposes tools to view stats, list node instances, create and manage node lifecycle (start, stop, delete, upgrade, recycle).
  - MCP server launches as a background task when enabled; startup is logged.

- **Documentation**
  - Added README section with MCP server setup, usage examples, CLI instructions, and a demo GIF.

- **Chores**
  - Added optional dependencies and feature flags to enable the MCP server.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->