### PR TITLE
feat: keep failed batch on queue till user dismisses it

### DIFF
--- a/src/types/batch.rs
+++ b/src/types/batch.rs
@@ -14,6 +14,8 @@ pub enum BatchStatus {
     Scheduled,
     /// The batch is currently being processed.
     InProgress,
+    /// The batch failed to complete successfully, with a message describing the failure.
+    Failed(String),
 }
 
 impl fmt::Display for BatchStatus {
@@ -21,7 +23,14 @@ impl fmt::Display for BatchStatus {
         match self {
             BatchStatus::Scheduled => write!(f, "Scheduled"),
             BatchStatus::InProgress => write!(f, "In progress"),
+            BatchStatus::Failed(msg) => write!(f, "Failed: {msg}"),
         }
+    }
+}
+
+impl BatchStatus {
+    pub fn is_failed(&self) -> bool {
+        matches!(self, Self::Failed(_))
     }
 }
 


### PR DESCRIPTION
Keep failed batch in queue, allowing user to view failure reason, removing it when the user decides to dismiss it.

Resolves #12 .

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a explicit "Failed" batch status that displays a failure reason in the UI.

* **Improvements**
  * Visual updates for failed batches: failure-themed styling, title "Batch Failed", cancel button becomes "Dismiss", and failure panel shown while "Time remaining" is hidden.
  * Failed batches are retained for inspection; cancellation now treats failed batches as dismissible without triggering cancellation signaling.

* **Bug Fixes**
  * More reliable batch progress and status updates; node locks are released when batches are interrupted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->